### PR TITLE
Fix file force rescan adding unintended files

### DIFF
--- a/arch_blueprint_generator/sync/arch_sync.py
+++ b/arch_blueprint_generator/sync/arch_sync.py
@@ -160,17 +160,9 @@ class ArchSync:
                 file_count += len(rel_map.get_nodes_by_type(NodeType.FILE))
             elif os.path.isfile(path):
                 logger.info(f"Rescanning file: {path}")
-                # For individual files, we need to determine the parent directory
-                parent_dir = os.path.dirname(path)
-                file_name = os.path.basename(path)
-                
-                # Scan the parent directory but filter for only this file
-                scanner = PathScanner(
-                    parent_dir,
-                    relationship_map=self.relationship_map,
-                    json_mirrors=self.json_mirrors
-                )
-                scanner.scan()
+                # Remove any existing nodes for the file then add it back
+                self._clean_existing_file_nodes(path)
+                self._add_file(path)
                 file_count += 1
         
         # Since we're doing a force rescan, count all files as updates

--- a/docs/epic_1/bug_fixes/bug_fixes_story_1.4.md
+++ b/docs/epic_1/bug_fixes/bug_fixes_story_1.4.md
@@ -26,6 +26,10 @@
    - Added .architectum to excluded directories
    - Fixed the relationship_map.to_json method to include the detail_level from the scanner
 
+6. **Force Rescanning a File Added Siblings**
+   - Updated ArchSync to clean and re-add only the specified file during a force rescan
+   - Added a regression test to ensure sibling files are not unintentionally scanned
+
 ## Files Modified
 
 1. `arch_blueprint_generator/models/relationship_map.py`
@@ -52,6 +56,12 @@
 
 7. `tests/unit/models/test_json_mirrors.py`
    - Updated test_to_json to use DetailLevel.DETAILED
+
+8. `arch_blueprint_generator/sync/arch_sync.py`
+   - Fixed force rescan so only the specified file is reprocessed
+
+9. `tests/unit/sync/test_arch_sync.py`
+   - Added regression test for single-file force rescan
 
 ## Verification
 

--- a/tests/unit/sync/test_arch_sync.py
+++ b/tests/unit/sync/test_arch_sync.py
@@ -124,6 +124,16 @@ class TestArchSync:
         
         # Verify file is in the JSON mirrors
         assert arch_sync.json_mirrors.exists(test_files["file1"]) is True
+
+    def test_force_rescan_single_file_only_updates_specified_file(self, arch_sync, test_files):
+        """Force rescan of a single file should not scan sibling files."""
+        arch_sync.sync([test_files["file1"]], False, True)
+
+        # Ensure other files were not added
+        file2_node_id = f"file:{test_files['file2']}"
+        subfile_node_id = f"file:{test_files['subfile']}"
+        assert arch_sync.relationship_map.get_node(file2_node_id) is None
+        assert arch_sync.relationship_map.get_node(subfile_node_id) is None
     
     def test_sync_modified_file(self, arch_sync, test_files):
         """Test synchronizing a modified file."""


### PR DESCRIPTION
## Summary
- avoid scanning entire directory when forcing rescan of a single file
- add regression test for force rescan on individual file
- document fix in bug fixes log

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*
