### PR TITLE
Start Epic 2: YAML blueprint configs

### DIFF
--- a/arch_blueprint_generator/cli/commands.py
+++ b/arch_blueprint_generator/cli/commands.py
@@ -16,6 +16,7 @@ from arch_blueprint_generator.utils.logging import configure_logging, get_logger
 from arch_blueprint_generator.scanner.path_scanner import PathScanner
 from arch_blueprint_generator.models.detail_level import DetailLevel
 from arch_blueprint_generator.errors.exceptions import BlueprintError
+from arch_blueprint_generator.yaml import load_blueprint_config, YAMLValidationError
 
 app = typer.Typer(help="Architectum Blueprint Generator")
 blueprint_app = typer.Typer(help="Generate blueprints from code.")
@@ -181,6 +182,62 @@ def blueprint_file(
 
     except Exception as e:
         error(f"Error generating blueprint: {str(e)}", exit_code=1)
+
+
+@blueprint_app.command("create")
+def blueprint_create(
+    yaml: str = typer.Option(
+        ..., "--yaml", "-f", help="YAML blueprint definition file"
+    ),
+    output: str = typer.Option(
+        "-", "--output", "-o", help="Output file (- for stdout)"
+    ),
+    format: OutputFormat = typer.Option(
+        OutputFormat.JSON, "--format", "-m", help="Output format"
+    ),
+    pretty: bool = typer.Option(True, "--pretty/--compact", help="Pretty print output"),
+) -> None:
+    """Create a blueprint from a YAML definition."""
+    try:
+        try:
+            config = load_blueprint_config(yaml)
+        except (FileNotFoundError, YAMLValidationError) as e:
+            error(str(e), exit_code=1)
+
+        files = [c.file for c in config.components]
+        if not files:
+            error("No files specified in YAML", exit_code=1)
+
+        root_dir = os.path.commonpath(files)
+        scanner = PathScanner(root_dir)
+        relationship_map, json_mirrors = scanner.scan()
+
+        from arch_blueprint_generator.blueprints.factory import BlueprintFactory
+
+        dl = DetailLevel.from_string(config.detail_level)
+        blueprint = BlueprintFactory.create_file_blueprint(
+            relationship_map,
+            json_mirrors,
+            files,
+            name=config.name,
+            detail_level=dl,
+        )
+        blueprint.generate()
+
+        if format == OutputFormat.JSON:
+            content = json.dumps(blueprint.to_json(), indent=2 if pretty else None)
+        else:
+            content = blueprint.to_xml()
+
+        if output == "-":
+            typer.echo(content)
+        else:
+            with open(output, "w", encoding="utf-8") as f:
+                f.write(content)
+            success(f"Blueprint written to {output}")
+
+    except Exception as e:
+        error(f"Error creating blueprint: {str(e)}", exit_code=1)
 
 
 @app.command()

--- a/arch_blueprint_generator/yaml/__init__.py
+++ b/arch_blueprint_generator/yaml/__init__.py
@@ -1,0 +1,1 @@
+from .blueprint_config import BlueprintConfig, load_blueprint_config, YAMLValidationError, Component

--- a/arch_blueprint_generator/yaml/blueprint_config.py
+++ b/arch_blueprint_generator/yaml/blueprint_config.py
@@ -1,0 +1,141 @@
+"""YAML blueprint configuration parsing."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional, Dict, Any
+import os
+import re
+
+
+@dataclass
+class Component:
+    """Represents a single blueprint component."""
+    file: str
+    elements: List[str] = field(default_factory=list)
+
+
+@dataclass
+class BlueprintConfig:
+    """Represents a blueprint configuration loaded from YAML."""
+    type: str
+    name: str
+    description: Optional[str] = None
+    persistence: str = "temporary"
+    detail_level: str = "standard"
+    components: List[Component] = field(default_factory=list)
+
+
+class YAMLValidationError(Exception):
+    """Raised when a YAML configuration is invalid."""
+
+
+def _parse_value(value: str) -> Any:
+    value = value.strip()
+    if value == "" or value is None:
+        return None
+    if value in {"true", "True"}:
+        return True
+    if value in {"false", "False"}:
+        return False
+    if re.fullmatch(r"-?\d+", value):
+        return int(value)
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        if not inner:
+            return []
+        return [item.strip() for item in inner.split(",")]
+    if (value.startswith("'") and value.endswith("'")) or (
+        value.startswith('"') and value.endswith('"')
+    ):
+        return value[1:-1]
+    return value
+
+
+def _parse_yaml(text: str) -> Dict[str, Any]:
+    """Very small YAML subset parser supporting dicts and lists."""
+    result: Dict[str, Any] = {}
+    stack: List[tuple[int, Any]] = [(0, result)]
+    last_key_stack: List[Optional[str]] = [None]
+
+    for raw_line in text.splitlines():
+        if not raw_line.strip() or raw_line.strip().startswith("#"):
+            continue
+        indent = len(raw_line) - len(raw_line.lstrip())
+        line = raw_line.lstrip()
+
+        while stack and indent < stack[-1][0]:
+            stack.pop()
+            last_key_stack.pop()
+        parent = stack[-1][1]
+        last_key = last_key_stack[-1]
+
+        if line.startswith("- "):
+            item_line = line[2:]
+            if isinstance(parent, dict):
+                if last_key is None:
+                    raise YAMLValidationError("List item with no key")
+                if not isinstance(parent[last_key], list):
+                    parent[last_key] = []
+                parent = parent[last_key]
+            if isinstance(parent, list):
+                if ":" in item_line:
+                    key, val = item_line.split(":", 1)
+                    d: Dict[str, Any] = {key.strip(): _parse_value(val)}
+                    parent.append(d)
+                    if val.strip() == "":
+                        stack.append((indent + 2, d))
+                        last_key_stack.append(key.strip())
+                    else:
+                        last_key_stack.append(None)
+                else:
+                    parent.append(_parse_value(item_line))
+                    last_key_stack.append(None)
+            else:
+                raise YAMLValidationError("Invalid list structure")
+        else:
+            if ":" not in line:
+                raise YAMLValidationError(f"Invalid line: {raw_line}")
+            key, val = line.split(":", 1)
+            key = key.strip()
+            val = val.strip()
+            if isinstance(parent, list):
+                raise YAMLValidationError("Cannot add key-value pair inside list without dash")
+            parent[key] = _parse_value(val)
+            last_key_stack[-1] = key
+            if val == "":
+                stack.append((indent + 2, parent[key]))
+                last_key_stack.append(None)
+            else:
+                last_key_stack.append(None)
+    return result
+
+
+def load_blueprint_config(path: str) -> BlueprintConfig:
+    """Load and validate a blueprint YAML definition."""
+    if not os.path.exists(path):
+        raise FileNotFoundError(path)
+    text = open(path, "r", encoding="utf-8").read()
+    data = _parse_yaml(text)
+    if "type" not in data or "components" not in data:
+        raise YAMLValidationError("Blueprint config must contain 'type' and 'components'")
+
+    components = []
+    for comp in data.get("components", []):
+        if isinstance(comp, dict):
+            file = comp.get("file")
+            if not file:
+                raise YAMLValidationError("Component missing 'file'")
+            elements = comp.get("elements", [])
+            if not isinstance(elements, list):
+                raise YAMLValidationError("'elements' must be a list")
+            components.append(Component(file=file, elements=elements))
+        else:
+            raise YAMLValidationError("Invalid component entry")
+
+    return BlueprintConfig(
+        type=data.get("type"),
+        name=data.get("name", "blueprint"),
+        description=data.get("description"),
+        persistence=data.get("persistence", "temporary"),
+        detail_level=data.get("detail_level", "standard"),
+        components=components,
+    )

--- a/tests/unit/cli/test_blueprint_command.py
+++ b/tests/unit/cli/test_blueprint_command.py
@@ -4,6 +4,7 @@ import json
 import os
 import pytest
 from typer.testing import CliRunner
+import textwrap
 
 from arch_blueprint_generator.cli.commands import app
 
@@ -87,3 +88,40 @@ def test_blueprint_file_with_detailed_level(runner, tmp_path):
     assert output_file.exists()
     data = json.loads(output_file.read_text())
     assert len(data["content"]["files"]) == 2
+
+
+def test_blueprint_create_from_yaml(runner, tmp_path):
+    """Generate a blueprint using the create command with YAML."""
+    yaml_content = textwrap.dedent(
+        """
+        type: file
+        name: sample
+        detail_level: minimal
+        components:
+          - file: a.py
+            elements: []
+          - file: b.py
+            elements: []
+        """
+    )
+    bp_yaml = tmp_path / "bp.yaml"
+    bp_yaml.write_text(yaml_content)
+
+    (tmp_path / "a.py").write_text("def a():\n    pass")
+    (tmp_path / "b.py").write_text("def b():\n    pass")
+    output_file = tmp_path / "out.json"
+
+    result = runner.invoke(
+        app,
+        [
+            "blueprint",
+            "create",
+            "-f",
+            str(bp_yaml),
+            "--output",
+            str(output_file),
+        ],
+    )
+    assert result.exit_code == 0
+    assert output_file.exists()
+

--- a/tests/unit/yaml/test_blueprint_config.py
+++ b/tests/unit/yaml/test_blueprint_config.py
@@ -1,0 +1,35 @@
+import textwrap
+import tempfile
+from arch_blueprint_generator.yaml import load_blueprint_config, YAMLValidationError
+
+
+def test_load_blueprint_config():
+    content = textwrap.dedent(
+        """
+        type: file
+        name: mybp
+        components:
+          - file: test.py
+            elements: []
+        """
+    )
+    with tempfile.NamedTemporaryFile('w+', delete=False) as f:
+        f.write(content)
+        path = f.name
+    config = load_blueprint_config(path)
+    assert config.type == 'file'
+    assert config.name == 'mybp'
+    assert len(config.components) == 1
+    assert config.components[0].file == 'test.py'
+
+
+def test_invalid_yaml(tmp_path):
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("type: file\ncomponents:\n  - bad")
+    try:
+        load_blueprint_config(str(bad))
+    except YAMLValidationError:
+        assert True
+    else:
+        assert False, "expected validation error"
+


### PR DESCRIPTION
## Summary
- add YAML parsing module with tiny parser and validation
- expose blueprint creation from YAML in CLI
- test YAML parser and CLI create command

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*