### PR TITLE
Implement method-based blueprint

### DIFF
--- a/arch_blueprint_generator/blueprints/__init__.py
+++ b/arch_blueprint_generator/blueprints/__init__.py
@@ -4,4 +4,5 @@ Blueprint module initialization.
 
 from arch_blueprint_generator.blueprints.base import Blueprint
 from arch_blueprint_generator.blueprints.file_based import FileBasedBlueprint
+from arch_blueprint_generator.blueprints.method_based import MethodBasedBlueprint
 from arch_blueprint_generator.blueprints.factory import BlueprintFactory

--- a/arch_blueprint_generator/blueprints/factory.py
+++ b/arch_blueprint_generator/blueprints/factory.py
@@ -13,6 +13,7 @@ from arch_blueprint_generator.utils.logging import get_logger
 
 # Import implementation classes
 from arch_blueprint_generator.blueprints.file_based import FileBasedBlueprint
+from arch_blueprint_generator.blueprints.method_based import MethodBasedBlueprint
 
 logger = get_logger(__name__)
 
@@ -28,6 +29,7 @@ class BlueprintFactory:
     # Registry of blueprint types
     _blueprint_types: Dict[str, Type[Blueprint]] = {
         "FileBasedBlueprint": FileBasedBlueprint,
+        "MethodBasedBlueprint": MethodBasedBlueprint,
         # More blueprint types will be added here as they are implemented
     }
     
@@ -137,4 +139,24 @@ class BlueprintFactory:
             name=name,
             detail_level=detail_level,
             file_paths=file_paths
+        )
+
+    @classmethod
+    def create_method_blueprint(
+        cls,
+        relationship_map: RelationshipMap,
+        json_mirrors: JSONMirrors,
+        components: Dict[str, List[str]],
+        name: Optional[str] = None,
+        detail_level: DetailLevel = DetailLevel.STANDARD,
+    ) -> MethodBasedBlueprint:
+        """Create a method-based blueprint."""
+
+        return cls.create_blueprint(
+            "MethodBasedBlueprint",
+            relationship_map,
+            json_mirrors,
+            name=name,
+            detail_level=detail_level,
+            components=components,
         )

--- a/arch_blueprint_generator/blueprints/method_based.py
+++ b/arch_blueprint_generator/blueprints/method_based.py
@@ -1,0 +1,134 @@
+"""Method-based blueprint implementation."""
+
+from __future__ import annotations
+
+import os
+from typing import Dict, List, Any, Optional
+
+from arch_blueprint_generator.models.relationship_map import RelationshipMap
+from arch_blueprint_generator.models.json_mirrors import JSONMirrors, FileContent
+from arch_blueprint_generator.models.nodes import FileNode
+from arch_blueprint_generator.models.detail_level import DetailLevel
+from arch_blueprint_generator.blueprints.base import Blueprint
+from arch_blueprint_generator.errors.exceptions import BlueprintError
+from arch_blueprint_generator.utils.logging import get_logger
+from arch_blueprint_generator.extractors import MethodExtractor
+
+
+logger = get_logger(__name__)
+
+
+class MethodBasedBlueprint(Blueprint):
+    """Blueprint focusing on specific methods within files."""
+
+    def __init__(
+        self,
+        relationship_map: RelationshipMap,
+        json_mirrors: JSONMirrors,
+        components: Dict[str, List[str]],
+        name: Optional[str] = None,
+        detail_level: DetailLevel = DetailLevel.STANDARD,
+    ) -> None:
+        super().__init__(relationship_map, json_mirrors, name, detail_level)
+
+        if not components:
+            raise BlueprintError("At least one file component must be specified")
+
+        self.components: Dict[str, List[str]] = {
+            os.path.abspath(path): elems for path, elems in components.items()
+        }
+
+        self.missing: List[str] = []
+        self._element_to_file: Dict[str, str] = {}
+
+        self._validate_file_paths()
+
+    def generate(self) -> None:
+        """Generate a method-based blueprint."""
+
+        self.content = {"files": [], "relationships": [], "missing_methods": []}
+
+        for file_path, methods in self.components.items():
+            info = self._process_file(file_path, methods)
+            if info:
+                self.content["files"].append(info)
+
+        self._add_relationships()
+        if self.missing:
+            self.content["missing_methods"] = self.missing
+
+        logger.info(
+            f"Generated method-based blueprint for {len(self.components)} files"
+        )
+
+    def _process_file(self, file_path: str, methods: List[str]) -> Optional[Dict[str, Any]]:
+        file_info: Dict[str, Any] = {"path": file_path, "elements": []}
+
+        file_node_id = f"file:{file_path}"
+        file_node = self.relationship_map.get_node(file_node_id, self.detail_level)
+
+        if file_node and isinstance(file_node, FileNode):
+            file_info["extension"] = file_node.extension
+            if self.detail_level != DetailLevel.MINIMAL and file_node.metadata:
+                file_info["metadata"] = file_node.metadata
+
+        file_content = self.json_mirrors.get_mirrored_content(file_path, self.detail_level)
+        if file_content and isinstance(file_content, FileContent):
+            if "extension" not in file_info:
+                file_info["extension"] = file_content.extension
+            if file_content.imports and self.detail_level != DetailLevel.MINIMAL:
+                file_info["imports"] = file_content.imports
+
+        extractor = MethodExtractor(self.relationship_map, self.json_mirrors)
+        elements, missing = extractor.extract(file_path, methods, self.detail_level)
+
+        for element in elements:
+            file_info["elements"].append(element)
+            if "id" in element:
+                self._element_to_file[element["id"]] = file_node_id
+
+        for m in missing:
+            self.missing.append(f"{file_path}:{m}")
+
+        if file_node or file_content:
+            return file_info
+        return None
+
+    def _add_relationships(self) -> None:
+        relationships: List[Dict[str, Any]] = []
+
+        def serialize(rel) -> Dict[str, Any]:
+            info = {
+                "type": rel.type.value,
+                "source_id": rel.source_id,
+                "target_id": rel.target_id,
+            }
+            if hasattr(rel, "line_number") and getattr(rel, "line_number") is not None:
+                info["line_number"] = rel.line_number
+            if self.detail_level == DetailLevel.DETAILED and rel.metadata:
+                info["metadata"] = rel.metadata
+            return info
+
+        element_ids = set(self._element_to_file.keys())
+        for element_id in element_ids:
+            for rel in self.relationship_map.get_outgoing_relationships(element_id, self.detail_level):
+                if rel.target_id in element_ids:
+                    relationships.append(serialize(rel))
+
+        self.content["relationships"] = relationships
+
+    def _validate_file_paths(self) -> None:
+        invalid = [p for p in self.components if not self._is_valid_file_path(p)]
+        if invalid:
+            raise BlueprintError(f"Invalid file paths: {invalid}")
+
+    def _is_valid_file_path(self, path: str) -> bool:
+        if os.path.isfile(path) and os.access(path, os.R_OK):
+            return True
+        file_node_id = f"file:{path}"
+        if self.relationship_map.get_node(file_node_id):
+            return True
+        if self.json_mirrors.exists(path):
+            return True
+        return False
+

--- a/arch_blueprint_generator/extractors/__init__.py
+++ b/arch_blueprint_generator/extractors/__init__.py
@@ -1,0 +1,6 @@
+"""Extraction utilities for blueprints."""
+
+from .method_extractor import MethodExtractor
+
+__all__ = ["MethodExtractor"]
+

--- a/arch_blueprint_generator/extractors/method_extractor.py
+++ b/arch_blueprint_generator/extractors/method_extractor.py
@@ -1,0 +1,88 @@
+"""Utilities for extracting method information from representations."""
+
+from typing import List, Tuple, Dict, Any
+
+from arch_blueprint_generator.models.relationship_map import RelationshipMap
+from arch_blueprint_generator.models.json_mirrors import JSONMirrors, FileContent
+from arch_blueprint_generator.models.nodes import NodeType
+from arch_blueprint_generator.models.detail_level import DetailLevel
+from arch_blueprint_generator.utils.logging import get_logger
+
+
+logger = get_logger(__name__)
+
+
+class MethodExtractor:
+    """Extract method details from both representations."""
+
+    def __init__(self, relationship_map: RelationshipMap, json_mirrors: JSONMirrors) -> None:
+        self.relationship_map = relationship_map
+        self.json_mirrors = json_mirrors
+
+    def extract(
+        self,
+        file_path: str,
+        method_names: List[str],
+        detail_level: DetailLevel = DetailLevel.STANDARD,
+    ) -> Tuple[List[Dict[str, Any]], List[str]]:
+        """Return information for requested methods and list missing ones."""
+
+        found: List[Dict[str, Any]] = []
+        missing: List[str] = []
+
+        file_content = self.json_mirrors.get_mirrored_content(file_path, detail_level)
+
+        for name in method_names:
+            element_info: Dict[str, Any] | None = None
+
+            # Search relationship map
+            for node_type in [NodeType.FUNCTION, NodeType.CLASS, NodeType.METHOD]:
+                nodes = self.relationship_map.nodes_by_type.get(node_type, {})
+                for node_id, node in nodes.items():
+                    if file_path in node_id and getattr(node, "name", None) == name:
+                        element_info = {
+                            "id": node.id,
+                            "type": node.type.value,
+                            "name": node.name,
+                        }
+                        if hasattr(node, "line_start") and node.line_start is not None:
+                            element_info["line_start"] = node.line_start
+                        if hasattr(node, "line_end") and node.line_end is not None:
+                            element_info["line_end"] = node.line_end
+                        if detail_level == DetailLevel.DETAILED and node.metadata:
+                            element_info["metadata"] = node.metadata
+                        break
+                if element_info:
+                    break
+
+            # Add data from JSON mirrors
+            if file_content and isinstance(file_content, FileContent):
+                elem = file_content.elements.get(name)
+                if elem:
+                    if element_info is None:
+                        element_info = {
+                            "name": elem.name,
+                            "type": elem.type,
+                        }
+                    element_info.setdefault("line_start", elem.line_start)
+                    element_info.setdefault("line_end", elem.line_end)
+                    if detail_level != DetailLevel.MINIMAL and elem.metadata:
+                        if detail_level == DetailLevel.DETAILED:
+                            element_info.setdefault("metadata", elem.metadata)
+                        else:
+                            essential = {
+                                k: v
+                                for k, v in elem.metadata.items()
+                                if k
+                                in {"visibility", "return_type", "parameters", "doc_summary"}
+                            }
+                            if essential:
+                                element_info.setdefault("metadata", essential)
+
+            if element_info:
+                found.append(element_info)
+            else:
+                missing.append(name)
+
+        return found, missing
+

--- a/arch_blueprint_generator/yaml/__init__.py
+++ b/arch_blueprint_generator/yaml/__init__.py
@@ -1,1 +1,11 @@
 from .blueprint_config import BlueprintConfig, load_blueprint_config, YAMLValidationError, Component
+from .method_definition import MethodBlueprintConfig, load_method_blueprint_config
+
+__all__ = [
+    "BlueprintConfig",
+    "load_blueprint_config",
+    "YAMLValidationError",
+    "Component",
+    "MethodBlueprintConfig",
+    "load_method_blueprint_config",
+]

--- a/arch_blueprint_generator/yaml/method_definition.py
+++ b/arch_blueprint_generator/yaml/method_definition.py
@@ -1,0 +1,39 @@
+"""YAML handling for method-based blueprints."""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from arch_blueprint_generator.yaml.blueprint_config import (
+    BlueprintConfig,
+    Component,
+    YAMLValidationError,
+    load_blueprint_config,
+)
+
+
+@dataclass
+class MethodBlueprintConfig:
+    """Structured configuration for a method-based blueprint."""
+
+    name: str
+    detail_level: str
+    components: Dict[str, List[str]] = field(default_factory=dict)
+
+
+def load_method_blueprint_config(path: str) -> MethodBlueprintConfig:
+    """Load a method blueprint YAML definition."""
+
+    config: BlueprintConfig = load_blueprint_config(path)
+    if config.type != "method":
+        raise YAMLValidationError("Blueprint type must be 'method'")
+
+    components: Dict[str, List[str]] = {
+        comp.file: comp.elements for comp in config.components
+    }
+
+    return MethodBlueprintConfig(
+        name=config.name,
+        detail_level=config.detail_level,
+        components=components,
+    )
+

--- a/docs/catalogs/feature_catalog.yaml
+++ b/docs/catalogs/feature_catalog.yaml
@@ -151,3 +151,28 @@
         - "_parse_value"
         - "_parse_yaml"
         - "load_blueprint_config"
+
+- feature: "Method-Based Blueprint Implementation"
+  files:
+    - path: "arch_blueprint_generator/blueprints/method_based.py"
+      classes:
+        - name: "MethodBasedBlueprint"
+          methods:
+            - "__init__"
+            - "generate"
+            - "_process_file"
+            - "_add_relationships"
+            - "_validate_file_paths"
+            - "_is_valid_file_path"
+      functions: []
+    - path: "arch_blueprint_generator/extractors/method_extractor.py"
+      classes:
+        - name: "MethodExtractor"
+          methods:
+            - "extract"
+      functions: []
+    - path: "arch_blueprint_generator/yaml/method_definition.py"
+      classes:
+        - name: "MethodBlueprintConfig"
+      functions:
+        - "load_method_blueprint_config"

--- a/docs/catalogs/project_catalog.yaml
+++ b/docs/catalogs/project_catalog.yaml
@@ -127,3 +127,29 @@
   tracking:
     json_representation: false
     system_map_updated: false
+
+- path: "arch_blueprint_generator/yaml/method_definition.py"
+  classes:
+    - "MethodBlueprintConfig"
+  functions:
+    - "load_method_blueprint_config"
+  tracking:
+    json_representation: false
+    system_map_updated: false
+
+- path: "arch_blueprint_generator/extractors/method_extractor.py"
+  classes:
+    - "MethodExtractor"
+  functions:
+    - "extract"
+  tracking:
+    json_representation: false
+    system_map_updated: false
+
+- path: "arch_blueprint_generator/blueprints/method_based.py"
+  classes:
+    - "MethodBasedBlueprint"
+  functions: []
+  tracking:
+    json_representation: false
+    system_map_updated: false

--- a/docs/epics/epic_3/story-3.1.md
+++ b/docs/epics/epic_3/story-3.1.md
@@ -1,6 +1,6 @@
 # Story 3.1: Implement Method-Based Blueprint Logic
 
-## Status: Approved
+## Status: In-Progress - 2025-05-23
 
 ## Story
 
@@ -101,10 +101,10 @@ As an AI agent (via Architectum), I want to request a Method-Based Blueprint by 
 
 ## Story Progress Notes
 
-### Agent Model Used: `<To be filled by implementing agent>`
+### Agent Model Used: gpt-4
 
 ### Completion Notes List
 {To be filled during implementation}
 
 ### Change Log
-{To be updated during implementation}
+- 2025-05-23 - Started implementation - Dev Agent

--- a/tests/unit/blueprints/test_method_based.py
+++ b/tests/unit/blueprints/test_method_based.py
@@ -1,0 +1,80 @@
+"""Tests for the MethodBasedBlueprint class."""
+
+import os
+import tempfile
+from typing import Dict, List
+
+import pytest
+
+from arch_blueprint_generator.models.relationship_map import RelationshipMap
+from arch_blueprint_generator.models.json_mirrors import JSONMirrors, FileContent, CodeElement
+from arch_blueprint_generator.models.nodes import (
+    FileNode,
+    FunctionNode,
+    ContainsRelationship,
+)
+from arch_blueprint_generator.blueprints.method_based import MethodBasedBlueprint
+
+
+class TestMethodBasedBlueprint:
+    """Tests for method-focused blueprint generation."""
+
+    @pytest.fixture
+    def temp_file(self, tmp_path) -> str:
+        path = tmp_path / "file.py"
+        path.write_text("def foo():\n    return 1\n")
+        return str(path)
+
+    @pytest.fixture
+    def relationship_map(self, temp_file) -> RelationshipMap:
+        rm = RelationshipMap()
+        file_node = FileNode(f"file:{temp_file}", temp_file, ".py")
+        func_node = FunctionNode(
+            f"func:{temp_file}:foo",
+            "foo",
+            parameters=[],
+            return_type=None,
+            line_start=1,
+            line_end=2,
+        )
+        rm.add_node(file_node)
+        rm.add_node(func_node)
+        rm.add_relationship(ContainsRelationship(file_node.id, func_node.id))
+        return rm
+
+    @pytest.fixture
+    def json_mirrors(self, temp_file) -> JSONMirrors:
+        jm = JSONMirrors(os.path.dirname(temp_file))
+        elements = {
+            "foo": CodeElement("foo", "function", 1, 2, {})
+        }
+        jm.create_file_mirror(temp_file, elements, [])
+        return jm
+
+    def test_generate(self, relationship_map, json_mirrors, temp_file):
+        bp = MethodBasedBlueprint(
+            relationship_map,
+            json_mirrors,
+            {temp_file: ["foo"]},
+        )
+
+        bp.generate()
+
+        assert "files" in bp.content
+        assert len(bp.content["files"]) == 1
+        file_info = bp.content["files"][0]
+        assert file_info["path"] == temp_file
+        assert any(e["name"] == "foo" for e in file_info["elements"])
+
+    def test_missing_method(self, relationship_map, json_mirrors, temp_file):
+        bp = MethodBasedBlueprint(
+            relationship_map,
+            json_mirrors,
+            {temp_file: ["bar"]},
+        )
+
+        bp.generate()
+
+        assert bp.content.get("missing_methods")
+        assert f"{temp_file}:bar" in bp.content["missing_methods"]
+


### PR DESCRIPTION
## Summary
- start work on method-based blueprints
- add MethodBasedBlueprint and supporting extractor
- provide method YAML config loader
- register blueprint type and factory helper
- document progress in story file
- update catalogs
- add unit tests for MethodBasedBlueprint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'structlog')*